### PR TITLE
feat: fund stellar accounts in testnet

### DIFF
--- a/services/stellar-wallet/.prettierrc.json
+++ b/services/stellar-wallet/.prettierrc.json
@@ -3,7 +3,7 @@
 	"singleQuote": true,
 	"tabWidth": 2,
 	"useTabs": true,
-	"trailingComma": "es5",
+	"trailingComma": "all",
 	"printWidth": 100,
 	"endOfLine": "lf"
 }

--- a/services/stellar-wallet/eslint.config.ts
+++ b/services/stellar-wallet/eslint.config.ts
@@ -17,6 +17,9 @@ export default [
 			globals: {
 				process: 'readonly',
 				console: 'readonly',
+				fetch: 'readonly',
+				global: 'readonly',
+				globalThis: 'readonly',
 			},
 		},
 		plugins: {
@@ -63,6 +66,9 @@ export default [
 				afterEach: 'readonly',
 				beforeAll: 'readonly',
 				afterAll: 'readonly',
+				fetch: 'readonly',
+				global: 'readonly',
+				globalThis: 'readonly',
 			},
 		},
 	},

--- a/services/stellar-wallet/src/stellar/fund.ts
+++ b/services/stellar-wallet/src/stellar/fund.ts
@@ -1,0 +1,44 @@
+import { StrKey } from '@stellar/stellar-sdk'
+import { connect } from './client'
+
+/**
+ * Funds a Stellar account on testnet using Friendbot.
+ * @param publicKey - The public key of the account to fund.
+ */
+export async function fundAccount(publicKey: string): Promise<void> {
+	if (!StrKey.isValidEd25519PublicKey(publicKey)) {
+		throw new Error('Invalid Stellar public key')
+	}
+
+	const url = `https://friendbot.stellar.org?addr=${publicKey}`
+
+	const response = await fetch(url)
+	if (!response.ok) {
+		const errorBody = await response.text()
+		throw new Error(`Friendbot failed: ${response.status} ${errorBody}`)
+	}
+
+	const data = await response.json()
+	console.log(`✅ Account funded: ${publicKey}`, data)
+}
+
+/**
+ * Checks if the account balance is at least 1 XLM.
+ * @param publicKey - The public key of the account to check.
+ * @returns True if the account has at least 1 XLM, false otherwise.
+ */
+export async function checkBalance(publicKey: string): Promise<boolean> {
+	try {
+		const server = connect()
+		const account = await server.loadAccount(publicKey)
+		const balanceEntry = account.balances.find((b) => b.asset_type === 'native')
+
+		if (!balanceEntry) return false
+
+		const balance = Number.parseFloat(balanceEntry.balance)
+		return balance >= 1
+	} catch (error) {
+		console.error('❌ Failed to check balance:', error)
+		return false
+	}
+}

--- a/services/stellar-wallet/tests/stellar/fund.test.ts
+++ b/services/stellar-wallet/tests/stellar/fund.test.ts
@@ -1,0 +1,90 @@
+import { checkBalance, fundAccount } from '../../src/stellar/fund'
+
+// Mock fetch globally
+const mockedFetch = jest.fn() as unknown as typeof fetch
+global.fetch = mockedFetch
+
+// Mock connect and Horizon server
+jest.mock('../../src/stellar/client', () => ({
+	connect: () => ({
+		loadAccount: jest.fn().mockResolvedValue({
+			balances: [
+				{ asset_type: 'native', balance: '100.0000000' },
+				{ asset_type: 'credit_alphanum4', balance: '0.0000001' },
+			],
+		}),
+	}),
+}))
+
+const VALID_PUBLIC_KEY = 'GCCGMBN46TNVH2WL732DYB5WWBEJG5S4UDXAJGB7O3GPQJVVHVQOP5E7'
+const INVALID_PUBLIC_KEY = 'not-a-valid-key'
+
+describe('fundAccount', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('should fund a valid Stellar account', async () => {
+		;(global.fetch as unknown as jest.Mock).mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ success: true }),
+		})
+
+		await expect(fundAccount(VALID_PUBLIC_KEY)).resolves.not.toThrow()
+		expect(global.fetch).toHaveBeenCalledWith(
+			`https://friendbot.stellar.org?addr=${VALID_PUBLIC_KEY}`,
+		)
+	})
+
+	it('should throw an error for an invalid public key', async () => {
+		await expect(fundAccount(INVALID_PUBLIC_KEY)).rejects.toThrow('Invalid Stellar public key')
+		expect(global.fetch).not.toHaveBeenCalled()
+	})
+
+	it('should throw an error if Friendbot fails', async () => {
+		;(global.fetch as unknown as jest.Mock).mockResolvedValueOnce({
+			ok: false,
+			status: 400,
+			text: async () => 'Error funding account',
+		})
+
+		await expect(fundAccount(VALID_PUBLIC_KEY)).rejects.toThrow(
+			'Friendbot failed: 400 Error funding account',
+		)
+	})
+})
+
+describe('checkBalance', () => {
+	beforeEach(() => {
+		jest.resetModules()
+	})
+
+	it('should return true if balance is >= 1 XLM', async () => {
+		const result = await checkBalance(VALID_PUBLIC_KEY)
+		expect(result).toBe(true)
+	})
+
+	it('should return false if native balance is missing', async () => {
+		jest.doMock('../../src/stellar/client', () => ({
+			connect: () => ({
+				loadAccount: jest.fn().mockResolvedValue({ balances: [] }),
+			}),
+		}))
+
+		const { checkBalance: mockedCheckBalance } = await import('../../src/stellar/fund')
+		const result = await mockedCheckBalance(VALID_PUBLIC_KEY)
+		expect(result).toBe(false)
+	})
+
+	it('should return false on error', async () => {
+		jest.doMock('../../src/stellar/client', () => ({
+			connect: () => ({
+				loadAccount: jest.fn().mockRejectedValue(new Error('Network error')),
+			}),
+		}))
+
+		const { checkBalance: mockedCheckBalance } = await import('../../src/stellar/fund')
+		const result = await mockedCheckBalance(VALID_PUBLIC_KEY)
+		expect(result).toBe(false)
+	})
+})


### PR DESCRIPTION
## 🛠️ Issue

- Closes #106

## 📖 Description

This PR introduces the full implementation of the **Stellar account funding and balance verification logic** using the Friendbot service on the testnet.  
It provides two core functions:

- `fundAccount`: Funds a given Stellar public key using Friendbot.
- `checkBalance`: Checks whether the funded account has at least 1 XLM.

Unit tests are also included to ensure correct behavior for valid and invalid public keys, Friendbot failure, and balance checks.

## ✅ Changes Made

- Created `fundAccount` to request funds from Friendbot for testnet accounts.
- Implemented `checkBalance` to verify if an account holds at least 1 XLM.
- Mocked network requests (Friendbot and Horizon) in tests to avoid real network dependencies.
- Added unit tests to cover success, error, and edge cases.
- Ensured code passes ESLint and Prettier rules.

## 🖼️ Media (screenshots/videos)

<img width="1104" height="488" alt="image" src="https://github.com/user-attachments/assets/f4572887-400a-4c62-b47c-c2dd6e735aa7" />
