### PR TITLE
feat: implement transaction signing

### DIFF
--- a/services/stellar-wallet/src/db/kyc.ts
+++ b/services/stellar-wallet/src/db/kyc.ts
@@ -20,6 +20,14 @@ export type KycRow = {
 	status: string
 }
 
+export type AccountRow = {
+	id: number
+	user_id: number
+	public_key: string
+	/** Encrypted seed in the format "iv:tag:ciphertext" (all Base64) */
+	private_key: string
+}
+
 /**
  * Returns a single shared SQLite database instance (singleton).
  * Creates the file/directory if missing and applies PRAGMAs once.
@@ -147,4 +155,18 @@ export async function insertAccount(
 ): Promise<void> {
 	const sql = 'INSERT INTO accounts (user_id, public_key, private_key) VALUES (?, ?, ?);'
 	await run(db, sql, [args.user_id, args.public_key, args.private_key_encrypted])
+}
+
+/**
+ * Finds an account row by user_id or returns null.
+ * Reads from `accounts` table created by `initializeAccountsTable`.
+ */
+export async function findAccountByUserId(
+	db: sqlite3.Database,
+	userId: number,
+): Promise<AccountRow | null> {
+	const rows = await all<AccountRow>(db, 'SELECT * FROM accounts WHERE user_id = ? LIMIT 1;', [
+		userId,
+	])
+	return rows.length ? rows[0] : null
 }

--- a/services/stellar-wallet/src/stellar/sign.ts
+++ b/services/stellar-wallet/src/stellar/sign.ts
@@ -1,0 +1,65 @@
+import { type FeeBumpTransaction, Keypair, StrKey, type Transaction } from '@stellar/stellar-sdk'
+import type sqlite3 from 'sqlite3'
+import { connectDB } from '../db/kyc'
+import { findAccountByUserId } from '../db/kyc'
+import { decryptPrivateKey, getEncryptionKey } from '../utils/encryption'
+
+/** Union type for Stellar base transaction types we can sign. */
+export type StellarTx = Transaction | FeeBumpTransaction
+
+/**
+ * Fetches and decrypts a user's Stellar secret seed (S...).
+ * - Reads encrypted seed from `accounts.private_key` (format "iv:tag:ciphertext" base64)
+ * - Decrypts using AES-256-GCM with ENCRYPTION_KEY (32 bytes)
+ * - Returns a string that must start with 'S' and have length 56
+ *
+ * @throws Error('Account not found')  if the user has no account row
+ * @throws Error('Decryption failed')  if payload format or key is invalid
+ */
+export async function getPrivateKey(userId: number, db?: sqlite3.Database): Promise<string> {
+	const conn = db ?? (await connectDB())
+	const row = await findAccountByUserId(conn, userId)
+
+	if (!row) {
+		throw new Error('Account not found')
+	}
+
+	const encrypted = row.private_key
+	const key = getEncryptionKey()
+
+	let secret: string
+	try {
+		secret = decryptPrivateKey(encrypted, key)
+	} catch {
+		// Normalize all decryption/format errors to the required message
+		throw new Error('Decryption failed')
+	}
+
+	// Minimal shape validation to avoid returning garbage
+	if (!StrKey.isValidEd25519SecretSeed(secret)) {
+		throw new Error('Decryption failed')
+	}
+
+	return secret
+}
+
+/**
+ * Signs a Stellar Transaction or FeeBumpTransaction for the given user.
+ * - Retrieves user's decrypted S-secret via `getPrivateKey`
+ * - Builds a Keypair and invokes `tx.sign(keypair)`
+ *
+ * @returns The same transaction instance (signed)
+ * @throws Error('Account not found') or Error('Decryption failed') bubbled from `getPrivateKey`
+ */
+export async function signTransaction(
+	userId: number,
+	tx: StellarTx,
+	db?: sqlite3.Database,
+): Promise<StellarTx> {
+	const secret = await getPrivateKey(userId, db)
+	const keypair = Keypair.fromSecret(secret)
+
+	// Side-effect: signs the instance in-place (SDK API)
+	tx.sign(keypair)
+	return tx
+}

--- a/services/stellar-wallet/src/utils/encryption.ts
+++ b/services/stellar-wallet/src/utils/encryption.ts
@@ -41,3 +41,46 @@ export function encryptPrivateKey(plaintext: string, key: Buffer): string {
 
 	return `${iv.toString('base64')}:${tag.toString('base64')}:${ciphertext.toString('base64')}`
 }
+
+/**
+ * Decrypts payload produced by `encryptPrivateKey` using AES-256-GCM.
+ * Expects the compact format "iv:tag:ciphertext" (all Base64).
+ *
+ * Security notes:
+ * - Validates IV length (12 bytes) and auth tag length (16 bytes) before decrypting.
+ * - Throws on any malformed input or authentication failure.
+ */
+export function decryptPrivateKey(payload: string, key: Buffer): string {
+	const parts = payload.split(':')
+	if (parts.length !== 3) {
+		throw new Error('Invalid encrypted payload format')
+	}
+
+	const [ivB64, tagB64, ctB64] = parts
+
+	let iv: Buffer
+	let tag: Buffer
+	let ciphertext: Buffer
+	try {
+		iv = Buffer.from(ivB64, 'base64')
+		tag = Buffer.from(tagB64, 'base64')
+		ciphertext = Buffer.from(ctB64, 'base64')
+	} catch {
+		throw new Error('Invalid encrypted payload format')
+	}
+
+	// GCM requires a 12-byte nonce and a 16-byte auth tag for AES-256-GCM
+	if (iv.length !== 12 || tag.length !== 16 || ciphertext.length === 0) {
+		throw new Error('Invalid encrypted payload format')
+	}
+
+	try {
+		const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+		decipher.setAuthTag(tag)
+		const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+		return plaintext.toString('utf8')
+	} catch {
+		// Authentication failure or bad key
+		throw new Error('Invalid encrypted payload format')
+	}
+}

--- a/services/stellar-wallet/tests/stellar/sign.test.ts
+++ b/services/stellar-wallet/tests/stellar/sign.test.ts
@@ -1,0 +1,138 @@
+// Deterministic 32-byte key (Base64) for crypto operations in tests
+process.env.ENCRYPTION_KEY = Buffer.alloc(32, 7).toString('base64')
+
+import type { Keypair as StellarKeypair } from '@stellar/stellar-sdk'
+import type sqlite3 from 'sqlite3'
+import { type StellarTx, getPrivateKey, signTransaction } from '../../src/stellar/sign'
+import { encryptPrivateKey, getEncryptionKey } from '../../src/utils/encryption'
+
+type StellarSdkNS = typeof import('@stellar/stellar-sdk')
+
+// ---- Mocks (DB) ----
+const findAccountByUserIdMock = jest.fn<
+	Promise<{ id: number; user_id: number; public_key: string; private_key: string } | null>,
+	[sqlite3.Database, number]
+>()
+const connectDBMock = jest
+	.fn<Promise<sqlite3.Database>, []>()
+	.mockResolvedValue({} as unknown as sqlite3.Database)
+
+jest.mock('../../src/db/kyc', () => ({
+	findAccountByUserId: (db: sqlite3.Database, userId: number) =>
+		findAccountByUserIdMock(db, userId),
+	connectDB: () => connectDBMock(),
+}))
+
+// ---- Mocks (Stellar SDK) ----
+// Keep real exports (including StrKey) and only override Keypair.fromSecret.
+// This ensures strong seed validation still works.
+const fromSecretMock = jest.fn<StellarKeypair, [string]>()
+jest.mock('@stellar/stellar-sdk', () => {
+	const actual = jest.requireActual('@stellar/stellar-sdk') as typeof import('@stellar/stellar-sdk')
+	return {
+		...actual,
+		Keypair: {
+			...actual.Keypair,
+			fromSecret: (secret: string) => fromSecretMock(secret),
+		},
+	}
+})
+
+describe('stellar/sign module', () => {
+	const ORIGINAL_ENV = process.env.ENCRYPTION_KEY
+
+	// Use a real valid seed so StrKey.isValidEd25519SecretSeed passes.
+	const actualSdk = jest.requireActual('@stellar/stellar-sdk') as StellarSdkNS
+	const VALID_SECRET = actualSdk.Keypair.random().secret()
+	// Keep your variable name to minimize changes below.
+	const SECRET_56 = VALID_SECRET
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		process.env.ENCRYPTION_KEY = ORIGINAL_ENV
+	})
+
+	test('getPrivateKey -> returns decrypted S-secret (happy path)', async () => {
+		const key = getEncryptionKey()
+		const encrypted = encryptPrivateKey(SECRET_56, key)
+
+		findAccountByUserIdMock.mockResolvedValueOnce({
+			id: 1,
+			user_id: 1,
+			public_key: 'G'.padEnd(56, 'B'),
+			private_key: encrypted,
+		})
+
+		const secret = await getPrivateKey(1)
+		expect(secret).toBe(SECRET_56)
+	})
+
+	test('getPrivateKey -> throws "Account not found" when user has no account', async () => {
+		findAccountByUserIdMock.mockResolvedValueOnce(null)
+		await expect(getPrivateKey(123)).rejects.toThrow('Account not found')
+	})
+
+	test('getPrivateKey -> throws "Decryption failed" on wrong key', async () => {
+		const key = getEncryptionKey()
+		const encrypted = encryptPrivateKey(SECRET_56, key)
+
+		// Break the key to force authentication failure
+		process.env.ENCRYPTION_KEY = Buffer.alloc(32, 9).toString('base64')
+
+		findAccountByUserIdMock.mockResolvedValueOnce({
+			id: 2,
+			user_id: 2,
+			public_key: 'G'.padEnd(56, 'C'),
+			private_key: encrypted,
+		})
+
+		await expect(getPrivateKey(2)).rejects.toThrow('Decryption failed')
+	})
+
+	test('signTransaction -> signs the tx with Keypair.fromSecret and returns the same instance', async () => {
+		const key = getEncryptionKey()
+		const encrypted = encryptPrivateKey(SECRET_56, key)
+
+		findAccountByUserIdMock.mockResolvedValueOnce({
+			id: 10,
+			user_id: 10,
+			public_key: 'G'.padEnd(56, 'D'),
+			private_key: encrypted,
+		})
+
+		// Build a minimal signable tx with a typed sign method
+		const signFn = jest.fn<void, [StellarKeypair]>()
+		const tx = { sign: signFn } as unknown as StellarTx
+
+		// Use a strongly-typed return
+		const fakeKeypair = {} as unknown as StellarKeypair
+		fromSecretMock.mockReturnValueOnce(fakeKeypair)
+
+		// Spy consoles to assert secrets are not leaked
+		const logs: string[] = []
+		const errs: string[] = []
+		const warns: string[] = []
+		const logSpy = jest.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+			logs.push(args.map(String).join(' '))
+		})
+		const errSpy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+			errs.push(args.map(String).join(' '))
+		})
+		const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+			warns.push(args.map(String).join(' '))
+		})
+
+		const result = await signTransaction(10, tx)
+
+		expect(fromSecretMock).toHaveBeenCalledWith(SECRET_56)
+		expect(signFn).toHaveBeenCalledWith(fakeKeypair)
+		expect(result).toBe(tx)
+
+		const combined = [logs.join('\n'), errs.join('\n'), warns.join('\n')].join('\n')
+		expect(combined.includes(SECRET_56)).toBe(false)
+
+		logSpy.mockRestore()
+		errSpy.mockRestore()
+		warnSpy.mockRestore()
+	})
+})


### PR DESCRIPTION
## 🛠️ Issue

* Closes #137

## 📖 Description

This PR implements a secure Stellar transaction signing module in TypeScript. It retrieves and decrypts the user’s private key from SQLite (AES-256-GCM via `ENCRYPTION_KEY`) and signs `Transaction` or `FeeBumpTransaction` instances using Stellar SDK. Strong seed validation is enforced with `StrKey.isValidEd25519SecretSeed`. Errors are normalized (`Account not found` / `Decryption failed`), no secrets are logged, and the API is ready to be used by the upcoming `/wallet/send` endpoint.

## ✅ Changes Made

* Added `decryptPrivateKey` (AES-256-GCM, `"iv:tag:ciphertext"`) to `src/utils/encryption.ts`.
* Added `src/stellar/sign.ts` with:

  * `StellarTx` union type (`Transaction | FeeBumpTransaction`)
  * `getPrivateKey(userId, db?)` (reads from DB, decrypts, validates seed)
  * `signTransaction(userId, tx, db?)` (signs in-place and returns the same tx)
* Added DB helper `findAccountByUserId` in `src/db/kyc.ts`.
* Added unit tests `tests/stellar/sign.test.ts`:

  * happy path signing (DB/SDK mocked, no network calls),
  * `Account not found`,
  * `Decryption failed`,
  * assertion that secrets are never printed.
* Ensure ESLint/Prettier pass with no errors or warnings.

## 🖼️ Media (screenshots/videos)

<img width="1107" height="809" alt="image" src="https://github.com/user-attachments/assets/2b98aac2-9cf8-421e-b5f5-f31891f9cdd5" />
