### PR TITLE
feat: add transaction history endpoint

### DIFF
--- a/services/stellar-wallet/src/db/kyc.ts
+++ b/services/stellar-wallet/src/db/kyc.ts
@@ -211,3 +211,17 @@ export async function insertTransaction(
 	const sql = 'INSERT INTO transactions (user_id, transaction_hash, status) VALUES (?, ?, ?);'
 	await run(db, sql, [args.user_id, args.transaction_hash, args.status])
 }
+
+/**
+ * Retrieves all transactions for a given user, ordered by id DESC (newest first).
+ */
+export async function getTransactionsByUserId(
+	db: sqlite3.Database,
+	userId: number,
+): Promise<TransactionRow[]> {
+	return all<TransactionRow>(
+		db,
+		'SELECT id, user_id, transaction_hash, status FROM transactions WHERE user_id = ? ORDER BY id DESC;',
+		[userId],
+	)
+}


### PR DESCRIPTION
🛠️ Issue
Closes #139

📖 Description
This PR implements a new endpoint to retrieve transaction history for Stellar wallets on Testnet. The endpoint fetches transactions from the local SQLite database and enriches them with detailed information from the Horizon API, including timestamps, amounts, and destination addresses.

✅ Changes Made
- **Database Layer**: Added `getTransactionsByUserId()` helper function to query user transactions ordered by newest first
- **API Endpoint**: Implemented `GET /wallet/transactions/:user_id` with JWT authentication
  - Validates user_id parameter (must be positive integer)
  - Verifies JWT authorization (returns 403 if user_id doesn't match token)
  - Fetches transactions from SQLite database
  - Enriches each transaction with Horizon API data (timestamp, amount, destination)
  - Uses `Promise.all` for parallel Horizon API calls to optimize performance
  - Handles edge cases: empty transactions (returns 200 with empty array), invalid user_id (400), Horizon failures (500)
- **Tests**: Added comprehensive test suite with 10 test cases covering:
  - Success scenarios with enriched transaction data
  - Validation tests (invalid/negative/zero user_id)
  - Authorization tests (JWT mismatch, invalid JWT)
  - Error handling (Horizon API failures)
  - Edge cases (empty transactions, non-payment operations)
  - Achieved 100% coverage for the new endpoint

🖼️ Media (screenshots/videos)

<img width="864" height="854" alt="image" src="https://github.com/user-attachments/assets/0369b3b7-07c9-40a8-af43-3d733ba8fede" />
